### PR TITLE
Truncate displayed to the second

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,13 @@ jobs:
         with:
           go-version: 1.15
       - uses: actions/checkout@v1
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        if: matrix.os == 'ubuntu-latest'
+        with:
+          languages: go
       - name: make
         run: make
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1
+        if: matrix.os == 'ubuntu-latest'

--- a/internal/expiration/expiration_test.go
+++ b/internal/expiration/expiration_test.go
@@ -109,17 +109,17 @@ func TestExpiration_UpdateIconWithExpiration_allCurrent(t *testing.T) {
 aws_access_key_id=123456
 aws_secret_access_key=8765432
 foo=bar
-aws_expiration=2020-09-25T16:44:59.000Z
+aws_expiration=2020-09-25T16:44:59.250Z
 
 [uat]
 aws_access_key_id=asdfg
 aws_secret_access_key=jhgfd
-aws_expiration=2020-09-26T16:56:01.000Z
+aws_expiration=2020-09-26T16:56:01.100Z
 
 [dev]
 aws_access_key_id=987654
 aws_secret_access_key=2345678
-aws_expiration=2020-09-27T16:31:59.000Z
+aws_expiration=2020-09-27T16:31:59.300Z
 `), 0644)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Avoid displaying remaining time to the millisecond