### PR TITLE
Restrict GitHub actions permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on: [push]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 name: Perform release
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/cmd/aws_credential_expiration/main.go
+++ b/cmd/aws_credential_expiration/main.go
@@ -1,22 +1,12 @@
 package main
 
 import (
-	_ "embed"
 	"fmt"
 	"os"
 
 	"github.com/getlantern/systray"
 	"github.com/wjam/aws_credential_expiration/internal/expiration"
 )
-
-//go:embed red.png
-var redIcon []byte
-
-//go:embed amber.png
-var amberIcon []byte
-
-//go:embed green.png
-var greenIcon []byte
 
 func main() {
 	file, err := credentialsFile()

--- a/cmd/aws_credential_expiration/update.go
+++ b/cmd/aws_credential_expiration/update.go
@@ -1,12 +1,22 @@
 package main
 
 import (
+	_ "embed"
 	"time"
 
 	"github.com/wjam/aws_credential_expiration/internal/systray"
 
 	"github.com/0xAX/notificator"
 )
+
+//go:embed red.png
+var redIcon []byte
+
+//go:embed amber.png
+var amberIcon []byte
+
+//go:embed green.png
+var greenIcon []byte
 
 type update struct {
 	previousState state


### PR DESCRIPTION
Avoid potential supply-chain attacks by restricting what permissions the `GITHUB_TOKEN` has